### PR TITLE
Prevent Android Passcode Prompt on Orientation Change

### DIFF
--- a/android/app/src/main/java/com/example/vuvur/MainActivity.kt
+++ b/android/app/src/main/java/com/example/vuvur/MainActivity.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -101,7 +102,7 @@ fun AppNavigation() {
     val app = context.applicationContext as VuvurApplication
     val repository = app.settingsRepository
     val passcode by repository.passcodeFlow.collectAsState(initial = "LOADING")
-    var isUnlocked by remember { mutableStateOf(false) }
+    var isUnlocked by rememberSaveable { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
 
     if (passcode == "LOADING") {

--- a/android/app/src/main/java/com/example/vuvur/screens/LockScreen.kt
+++ b/android/app/src/main/java/com/example/vuvur/screens/LockScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -35,9 +36,9 @@ fun LockScreen(
     onUnlock: () -> Unit = {},
     onPasscodeSet: (String) -> Unit = {}
 ) {
-    var enteredCode by remember { mutableStateOf("") }
-    var firstEntry by remember { mutableStateOf("") }
-    var isConfirming by remember { mutableStateOf(false) }
+    var enteredCode by rememberSaveable { mutableStateOf("") }
+    var firstEntry by rememberSaveable { mutableStateOf("") }
+    var isConfirming by rememberSaveable { mutableStateOf(false) }
 
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()


### PR DESCRIPTION
This change addresses the issue where the Android application would show the passcode prompt again after a screen rotation, even if it had already been unlocked.

Changes:
- In `MainActivity.kt`, the `isUnlocked` state is now managed using `rememberSaveable`, ensuring the unlocked status is preserved across configuration changes.
- In `LockScreen.kt`, the `enteredCode`, `firstEntry`, and `isConfirming` states are also updated to use `rememberSaveable`. This ensures that if a user rotates the screen while entering or setting up a passcode, their progress is not lost.

These changes follow standard Jetpack Compose best practices for state persistence during Activity recreation.

---
*PR created automatically by Jules for task [6506537940156826857](https://jules.google.com/task/6506537940156826857) started by @djnixy*