### PR TITLE
🎨 Palette: Keyboard Accessibility Improvements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-13 - [Accessibility Improvements for Gallery and Viewer]
+**Learning:** Adding keyboard navigation (`Enter`/`Space`) and clear `:focus-visible` styles significantly improves usability for users who cannot use a mouse.
+**Action:** Always ensure interactive div elements have `tabIndex={0}`, `role="button"`, and appropriate `onKeyDown` handlers.

--- a/portal/src/App.css
+++ b/portal/src/App.css
@@ -346,6 +346,13 @@ body.no-scroll {
 .gallery-item:hover .image-dimension-overlay { opacity: 1; }
 .gallery-item:hover .lazy-image-placeholder img { opacity: 0.8; }
 
+.gallery-item:focus-visible {
+  outline: 3px solid var(--accent-color);
+  outline-offset: 2px;
+  border-radius: 4px;
+  z-index: 10;
+}
+
 .media-type-overlay {
   position: absolute;
   top: 50%;

--- a/portal/src/components/Gallery.jsx
+++ b/portal/src/components/Gallery.jsx
@@ -29,6 +29,15 @@ const Gallery = ({ files, onImageClick, lastImageRef }) => {
             key={file.path + index}
             className="gallery-item"
             onClick={() => onImageClick(index)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onImageClick(index);
+              }
+            }}
+            tabIndex={0}
+            role="button"
+            aria-label={`View ${file.type}${file.filename ? `: ${file.filename}` : ''}`}
           >
             <LazyImage
               src={`/api/thumbnails/${file.id}`}

--- a/portal/src/components/MediaSlide.jsx
+++ b/portal/src/components/MediaSlide.jsx
@@ -205,25 +205,25 @@ const MediaSlide = ({ file, index, currentIndex, onLike, onDelete, onClose, show
           ) : (
             // Only show controls when EXIF is hidden
             <div className="viewer-controls">
-              {file.type === 'image' && <button title="Show EXIF" onClick={handleShowExif}>ℹ️</button>}
-              <button title={file.liked ? "Unlike" : "Like"} onClick={handleLikeClick} className="heart-button">
+              {file.type === 'image' && <button title="Show EXIF" aria-label="Show EXIF" onClick={handleShowExif}>ℹ️</button>}
+              <button title={file.liked ? "Unlike" : "Like"} aria-label={file.liked ? "Unlike" : "Like"} onClick={handleLikeClick} className="heart-button">
                 <HeartIcon liked={file.liked} size={20} />
               </button>
-              <button title="Delete" onClick={handleDeleteClick}>🗑️</button>
+              <button title="Delete" aria-label="Delete" onClick={handleDeleteClick}>🗑️</button>
               {/* ✅ Add Close button here */}
-              <button title="Close Viewer" onClick={handleCloseClick}>&times;</button>
+              <button title="Close Viewer" aria-label="Close Viewer" onClick={handleCloseClick}>&times;</button>
             </div>
           )}
           {/* Show controls again when EXIF is expanded */}
           {showExif && (
             <div className="viewer-controls">
-              {file.type === 'image' && <button title="Hide EXIF" onClick={handleShowExif}>ℹ️</button>}
-              <button title={file.liked ? "Unlike" : "Like"} onClick={handleLikeClick} className="heart-button">
+              {file.type === 'image' && <button title="Hide EXIF" aria-label="Hide EXIF" onClick={handleShowExif}>ℹ️</button>}
+              <button title={file.liked ? "Unlike" : "Like"} aria-label={file.liked ? "Unlike" : "Like"} onClick={handleLikeClick} className="heart-button">
                 <HeartIcon liked={file.liked} size={20} />
               </button>
-              <button title="Delete" onClick={handleDeleteClick}>🗑️</button>
+              <button title="Delete" aria-label="Delete" onClick={handleDeleteClick}>🗑️</button>
               {/* ✅ Add Close button here too */}
-              <button title="Close Viewer" onClick={handleCloseClick}>&times;</button>
+              <button title="Close Viewer" aria-label="Close Viewer" onClick={handleCloseClick}>&times;</button>
             </div>
           )}
         </div>


### PR DESCRIPTION
💡 What: This PR introduces keyboard accessibility and screen reader support to the gallery and viewer. It makes gallery items focusable and interactive via the keyboard (Enter/Space keys) and adds descriptive ARIA labels to emoji-based buttons in the media viewer. It also adds a clear focus indicator for keyboard users.

🎯 Why: Users who rely on keyboard navigation or screen readers were previously unable to interact with the media gallery effectively, as items were only clickable with a mouse and buttons lacked textual descriptions.

📸 Before/After: 
- Before: Gallery items were not focusable via Tab; buttons in viewer only had visual emojis.
- After: Gallery items can be focused and "clicked" with the keyboard. Visual focus rings appear for keyboard users. Buttons have ARIA labels for screen readers.

♿ Accessibility: 
- Implemented \`tabIndex={0}\` and \`role="button"\` on gallery items.
- Added \`onKeyDown\` handlers for \`Enter\` and \`Space\`.
- Added \`aria-label\` to EXIF, Like, Delete, and Close buttons.
- Added \`:focus-visible\` CSS styles for better visual tracking during keyboard navigation.

---
*PR created automatically by Jules for task [12497497662127333456](https://jules.google.com/task/12497497662127333456) started by @djnixy*