### PR TITLE
Update GitHub Actions to latest stable major versions

### DIFF
--- a/.github/workflows/android-release.yaml
+++ b/.github/workflows/android-release.yaml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload APK to GitHub Release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ steps.bump_version.outputs.version }}
           name: Release v${{ steps.bump_version.outputs.version }}

--- a/.github/workflows/build_local.yaml
+++ b/.github/workflows/build_local.yaml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Build and push ${{ matrix.service }} image
         if: steps.set_suffix.outputs.tag_suffix != ''
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}


### PR DESCRIPTION
Updated the following GitHub Action workflows to use the latest stable major versions:

1. `.github/workflows/android-release.yaml`: Updated `softprops/action-gh-release` to `v3`.
2. `.github/workflows/build_local.yaml`: Updated `docker/build-push-action` to `v7`.

Changelog Summary:

| Action Name | Old Version | New Version | Reason |
|-------------|-------------|-------------|--------|
| softprops/action-gh-release | v2 | v3 | Support for Node.js 24 runtime |
| docker/build-push-action | v6 | v7 | Performance improvements and updated BuildKit support |

Full updated YAML contents are provided in the final response.

---
*PR created automatically by Jules for task [6786560189986077641](https://jules.google.com/task/6786560189986077641) started by @djnixy*