### PR TITLE
🛡️ Sentinel: [security improvement] Mitigate timing-based username enumeration in authenticate

### DIFF
--- a/api/app/db.py
+++ b/api/app/db.py
@@ -5,6 +5,10 @@ from argon2 import PasswordHasher, exceptions
 DB_PATH = os.environ.get("DB_PATH", "/app/data/app.db")
 ph = PasswordHasher()
 
+# Dummy hash for timing-safe authentication when user is not found
+DUMMY_HASH = "$argon2id$v=19$m=65536,t=3,p=4$VXOtvTe4r51h1rJnq1PO6A$HUNd0EVg4lTxWwuE5tGCvyP3Chcviu8OBtEeqJ3XF+o"
+
+
 def get_db():
     conn = sqlite3.connect(DB_PATH)
     conn.row_factory = sqlite3.Row
@@ -114,12 +118,13 @@ def authenticate(username, password):
     row = c.fetchone()
     conn.close()
 
-    if not row:
-        return False
+    # Use a dummy hash if the user is not found to prevent timing-based username enumeration.
+    # This ensures that password verification is always performed.
+    hash_to_verify = row["password"] if row else DUMMY_HASH
 
     try:
-        ph.verify(row["password"], password)
-        return True
+        ph.verify(hash_to_verify, password)
+        return row is not None
     except exceptions.VerifyMismatchError:
         return False
 


### PR DESCRIPTION
🛡️ Sentinel: [security improvement] Mitigate timing-based username enumeration in authenticate.

The `authenticate` function was previously returning `False` immediately if a username was not found, while performing an expensive hash verification if it was found. This created a timing side-channel allowing for username enumeration. 

I've introduced a pre-computed `DUMMY_HASH` and updated the logic to always perform a verification check, ensuring timing consistency regardless of whether the user exists.

---
*PR created automatically by Jules for task [3395913077662582001](https://jules.google.com/task/3395913077662582001) started by @djnixy*