### PR TITLE
⚡ Bolt: implement fast-path for cached thumbnails

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -25,3 +25,7 @@
 ## 2026-04-15 - [Ubiquitous Late Row Lookup]
 **Learning:** Extending the Late Row Lookup pattern from just `RANDOM()` to ALL sorted and paginated queries consistently reduces memory pressure. Since the gallery queries often fetch many records before applying `LIMIT`, keeping the sorted working set restricted to only IDs ensures that large EXIF JSON strings aren't loaded until the final page of results is ready.
 **Action:** Use Late Row Lookup for all paginated queries on tables with large columns, regardless of the sort order.
+
+## 2026-04-20 - [Bypassing DB for Cached Assets]
+**Learning:** Even with an optimized SQLite setup, querying the database for every thumbnail in a large gallery (20+ items) adds significant overhead and latency. Implementing a "fast-path" that checks the disk cache first using `send_from_directory` eliminates database contention and drastically improves perceived performance.
+**Action:** Always prioritize filesystem-based "fast-paths" for static or cached assets over database lookups.

--- a/api/app/thumbnails.py
+++ b/api/app/thumbnails.py
@@ -3,8 +3,8 @@ import io
 import subprocess
 import logging
 import threading
-from flask import Blueprint, send_file, abort
-from werkzeug.exceptions import HTTPException
+from flask import Blueprint, send_file, abort, send_from_directory
+from werkzeug.exceptions import HTTPException, NotFound
 from PIL import Image, ImageDraw
 from app.db import get_db
 from app.api_key_middleware import api_key_required
@@ -150,6 +150,17 @@ def get_media_row(media_id):
 @api_key_required
 def thumb(mid):
     """Serves a thumbnail. JPG for most, GIF for original GIFs."""
+    # ⚡ Bolt: Fast-path for cached thumbnails.
+    # Attempt to serve from disk directly, bypassing database query for path/type.
+    # This reduces gallery load time significantly by avoiding N database queries.
+    try:
+        return send_from_directory(THUMB_DIR, f"{mid}.jpg", mimetype="image/jpeg", max_age=31536000)
+    except NotFound:
+        try:
+            return send_from_directory(THUMB_DIR, f"{mid}.gif", mimetype="image/gif", max_age=31536000)
+        except NotFound:
+            pass # Not cached, proceed to generation path
+
     row = get_media_row(mid)
     src = row["path"]
     
@@ -157,10 +168,6 @@ def thumb(mid):
     thumb_ext = ".gif" if is_gif else ".jpg"
     dst = os.path.join(THUMB_DIR, f"{mid}{thumb_ext}")
     mime_type = "image/gif" if is_gif else "image/jpeg"
-
-    # 1. If the thumbnail exists, serve it instantly (Happy Path)
-    if os.path.exists(dst):
-        return send_file(dst, mimetype=mime_type, max_age=31536000)
 
     # 2. Source file is missing from disk
     if not os.path.exists(src):


### PR DESCRIPTION
Implemented a "fast-path" for thumbnail serving that checks the disk cache before querying the database. In a gallery view with 20+ items, the application was performing 20+ redundant database queries even when thumbnails were already generated and cached. This change significantly reduces latency and database contention for cached thumbnails, leading to faster perceived gallery load times. Verified with syntax checks and linting.

---
*PR created automatically by Jules for task [7136731210946899335](https://jules.google.com/task/7136731210946899335) started by @djnixy*